### PR TITLE
fix aide cron settings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -339,7 +339,8 @@ ubuntu1804cis_config_aide: true
 # AIDE cron settings
 ubuntu1804cis_aide_cron:
   cron_user: root
-  cron_file: /etc/crontab
+  # https://github.com/florianutz/ubuntu2004_cis/issues/33
+  cron_file: aide
   aide_job: '/usr/bin/aide.wrapper --config /etc/aide/aide.conf --check'
   aide_minute: 0
   aide_hour: 5


### PR DESCRIPTION
/domain @Betterment/squad-sre 
/no-platform @6f6d6172 

Context: 
Fixes an [issue](https://github.com/florianutz/ubuntu2004_cis/issues/33) with aide cron settings. Basically, there was a [change](https://github.com/ansible/ansible/pull/73591) in ansible versions >2.1 upstream that changed the behavior of how the cron module works. Now it won't let you edit `/etc/crontab` directly and instead enforces entries applied by the module itself.

This is currently preventing us from building new blueprint images.